### PR TITLE
change get typo3 version detection methode

### DIFF
--- a/classes/class.tx_caretakerinstance_Operation_GetRecord.php
+++ b/classes/class.tx_caretakerinstance_Operation_GetRecord.php
@@ -73,7 +73,7 @@ class tx_caretakerinstance_Operation_GetRecord implements tx_caretakerinstance_I
 		$field = $parameter['field'];
 		$value = $parameter['value'];
 		$checkEnableFields = $parameter['checkEnableFields'] == TRUE;
-		$t3Version = floatval($GLOBALS['TYPO3_VERSION']?$GLOBALS['TYPO3_VERSION']:$GLOBALS['TYPO_VERSION']);
+		$t3Version = floatval($GLOBALS['TYPO3_CONF_VARS']['SYS']['compat_version']);
 		if ($t3Version >= 6.0) {
 			\TYPO3\CMS\Frontend\Utility\EidUtility::initTCA();
 		} else {


### PR DESCRIPTION
Hi,

unfortunately the fix from last week don't work all times. Therefore I replace the detection with die compar_version. The version number is set by TYPO3.

Regards 

Simon

See also https://forge.typo3.org/issues/60452