### PR TITLE
[BUGFIX] Suggest caretaker extension

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -75,6 +75,7 @@ $EM_CONF[$_EXTKEY] = array(
 		'conflicts' => array(
 		),
 		'suggests' => array(
+			'caretaker' => '0.5.0',
 		),
 	),
 	'_md5_values_when_last_written' => 'a:5:{s:9:"ChangeLog";s:4:"9c48";s:10:"README.txt";s:4:"ee2d";s:12:"ext_icon.gif";s:4:"1bdc";s:19:"doc/wizard_form.dat";s:4:"9f12";s:20:"doc/wizard_form.html";s:4:"9378";}',


### PR DESCRIPTION
To resolve the right load order since TYPO3 6.2 the suggest
entry has to be set to caretaker extension