### PR TITLE
[BUGFIX] Remove int typecast that breaks the test when the value exce…

### DIFF
--- a/services/class.tx_caretakerinstance_DiskSpaceTestService.php
+++ b/services/class.tx_caretakerinstance_DiskSpaceTestService.php
@@ -114,7 +114,7 @@ class tx_caretakerinstance_DiskSpaceTestService extends tx_caretakerinstance_Rem
 			return 0;
 		}
 		if ($unit === '%') {
-			return (int)(ceil($diskSpace['total'] / 100 * $value));
+			return (double)(ceil($diskSpace['total'] / 100 * $value));
 		}
 		$factor = array_search($unit, array('b', 'kB', 'MB', 'GB', 'TB'));
 		return $value * (pow(1024, $factor));


### PR DESCRIPTION
When the result from ceil(...) is larger than the int limit typecasting it would into a negative value, breaking the test. Replaced it with double since its later being compared with "$diskSpace['free']" wich is also double and it fixed the problem.