### PR TITLE
Improve compatibility with TYPO CMS 7

### DIFF
--- a/eid/eid.tx_caretakerinstance.php
+++ b/eid/eid.tx_caretakerinstance.php
@@ -22,6 +22,7 @@
  *
  * This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 
 /**
  * This is a file of the caretaker project.
@@ -67,6 +68,10 @@ try {
 		} else {
 			header('HTTP/1.0 500 Invalid request');
 		}
+		// handle data string correctly, if typo3 added slashes to the post vars
+		if (VersionNumberUtility::convertVersionNumberToInteger(VersionNumberUtility::getCurrentTypo3Version()) < 7005000 && !get_magic_quotes_gpc()) {
+			$data = stripslashes($data);
+		}
 		$request = new tx_caretakerinstance_CommandRequest(
 				array(
 						'session_token' => $sessionToken,
@@ -74,7 +79,7 @@ try {
 								'host_address' => $remoteAddress
 						),
 						'data' => array(),
-						'raw' => stripslashes($data),
+						'raw' => $data,
 						'signature' => $signature
 				));
 

--- a/services/class.tx_caretakerinstance_TYPO3VersionTestService.php
+++ b/services/class.tx_caretakerinstance_TYPO3VersionTestService.php
@@ -112,6 +112,10 @@ class tx_caretakerinstance_TYPO3VersionTestService extends tx_caretakerinstance_
 			$versionDigits = explode('.', $versionString, 3);
 			$latestVersions = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\CMS\Core\Registry')->get('tx_caretaker', $allowUnstable ? 'TYPO3versions' : 'TYPO3versionsStable');
 			$newVersionString = $latestVersions[$versionDigits[0] . '.' . $versionDigits[1]];
+			if (!$newVersionString) {
+				// try with single version number, used since TYPO3 CMS 7
+				$newVersionString = $latestVersions[$versionDigits[0]];
+			}
 
 			if (!empty($newVersionString)) {
 				$versionString = $newVersionString;


### PR DESCRIPTION
4ceea51: Remote commands fail with the message "Command execution failed:
The request could not be certified" since TYPO3 CMS 7.5 on the client.

fd5d074: TYPO3VersionTestService does not work with TYPO3 CMS 7 releases.