### PR TITLE
Fixed: Added checkbox to check the extension updates test against the correct TYPO3 Version

### DIFF
--- a/services/ds.tx_caretakerinstance_FindExtensionUpdatesTestService.xml
+++ b/services/ds.tx_caretakerinstance_FindExtensionUpdatesTestService.xml
@@ -88,6 +88,15 @@
 					</config>
 				</TCEforms>
 			</ignore_extension_version_suffix>
+
+			<only_for_running_typo3_version>
+				<TCEforms>
+					<label>Should extension versions not for running TYPO3 version be ignored?</label>
+					<config>
+						<type>check</type>
+					</config>
+				</TCEforms>
+			</only_for_running_typo3_version>
 		</el>
 	</ROOT>
 </T3DataStructure>


### PR DESCRIPTION
The extension update ignores the TYPO3 version. This is fixed now.