### PR TITLE
[TASK] Raise TYPO3 version constraints for 8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "typo3-cms-extension",
   "homepage": "https://github.com/TYPO3-Caretaker/",
   "require": {
-    "typo3/cms-core": "^6.2.14|^7.6.0",
+    "typo3/cms-core": "^6.2.14|^7.6.0|^8.4.0",
     "typo3/cms": "*"
   },
   "require-dev": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -19,14 +19,14 @@ $EM_CONF[$_EXTKEY] = array (
   'lockType' => '',
   'author_company' => '',
   'version' => '0.7.7',
-  'TYPO3_version' => '6.2.0-7.99.99',
+  'TYPO3_version' => '6.2.0-8.99.99',
   'PHP_version' => '5.3.0-',
   'constraints' => 
   array (
     'depends' => 
     array (
       'cms' => '',
-      'typo3' => '6.2.0-7.99.99',
+      'typo3' => '6.2.0-8.99.99',
       'php' => '5.3.0-',
     ),
     'conflicts' => 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -52,9 +52,16 @@ $operations = array(
 		'CheckPathExists',
 		'GetDiskSpace',
 );
-foreach ($operations as $operationKey) {
-	$TYPO3_CONF_VARS['EXTCONF']['caretaker_instance']['operations'][$operationKey] =
-			'EXT:caretaker_instance/classes/class.tx_caretakerinstance_Operation_' . $operationKey . '.php:&tx_caretakerinstance_Operation_' . $operationKey;
+if (TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger(TYPO3\CMS\Core\Utility\VersionNumberUtility::getCurrentTypo3Version()) < 8000000) {
+    foreach ($operations as $operationKey) {
+        $TYPO3_CONF_VARS['EXTCONF']['caretaker_instance']['operations'][$operationKey] =
+                'EXT:caretaker_instance/classes/class.tx_caretakerinstance_Operation_' . $operationKey . '.php:&tx_caretakerinstance_Operation_' . $operationKey;
+    }
+} else {
+    foreach ($operations as $operationKey) {
+        // register operations without file path for CMS 8 or higher
+        $TYPO3_CONF_VARS['EXTCONF']['caretaker_instance']['operations'][$operationKey] = 'tx_caretakerinstance_Operation_' . $operationKey;
+    }
 }
 
 require(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('caretaker_instance') . '/ext_conf_include.php');


### PR DESCRIPTION
* allow installation in TYPO3 CMS 8

It looks like the extension is working without further changes in TYPO3 CMS 8, so raise version constraints to make it installable in CMS 8.