### PR TITLE
[BUGFIX] Use correct TYPO3 version of instance for extension updates

### DIFF
--- a/services/class.tx_caretakerinstance_FindExtensionUpdatesTestService.php
+++ b/services/class.tx_caretakerinstance_FindExtensionUpdatesTestService.php
@@ -287,13 +287,16 @@ class tx_caretakerinstance_FindExtensionUpdatesTestService extends tx_caretakeri
             /** @var TYPO3\CMS\Extensionmanager\Domain\Model\Extension $extension */
             foreach ($extensionAllVersions as $extensionVersion) {
                 /** @var TYPO3\CMS\Extensionmanager\Domain\Model\Dependency $dependency */
+                $compatible = true;
                 foreach ($extensionVersion->getDependencies() as $dependency) {
-                    if ($dependency->getIdentifier() == 'typo3'
-                        && $this->checkVersionRange($typo3Version, $dependency->getLowestVersion(), $dependency->getHighestVersion())
-                    ) {
-                        $extension = $extensionVersion;
-                        break 2;
+                    if ($dependency->getIdentifier() == 'typo3') {
+                        $compatible = $this->checkVersionRange($typo3Version, $dependency->getLowestVersion(), $dependency->getHighestVersion());
+                        break;
                     }
+                }
+                if ($compatible) {
+                    $extension = $extensionVersion;
+                    break;
                 }
             }
         }


### PR DESCRIPTION
If the option to ignore non-compatible version of an extension update is
enabled the correct instance version is fetched and used now.

Resolves: https://github.com/TYPO3-Caretaker/caretaker/issues/62