### PR TITLE
[FEATURE] Add new option to ignore major extension versions

### DIFF
--- a/services/ds.tx_caretakerinstance_FindExtensionUpdatesTestService.xml
+++ b/services/ds.tx_caretakerinstance_FindExtensionUpdatesTestService.xml
@@ -89,6 +89,15 @@
                 </TCEforms>
             </ignore_extension_version_suffix>
 
+            <ignore_major_extension_version>
+                <TCEforms>
+                    <label>Should major extension versions be ignored?</label>
+                    <config>
+                        <type>check</type>
+                    </config>
+                </TCEforms>
+            </ignore_major_extension_version>
+
             <only_for_running_typo3_version>
                 <TCEforms>
                     <label>Should extension versions not for running TYPO3 version be ignored?</label>


### PR DESCRIPTION
This patch adds a new option to ignore major extension versions in
tx_caretakerinstance_FindExtensionUpdatesTestService. This prevents
errors/warnings if a new major extension version is released but there
is no need to upgrade or an upgrade would be highly breaking.