### PR TITLE
[FEATURE] Multiple IPs and hostenames for security.clientHostAddressRestriction

### DIFF
--- a/classes/class.tx_caretakerinstance_SecurityManager.php
+++ b/classes/class.tx_caretakerinstance_SecurityManager.php
@@ -279,8 +279,17 @@ class tx_caretakerinstance_SecurityManager implements tx_caretakerinstance_ISecu
         }
         $clientHostRestrictionAddresses = array_map('trim', explode(',', $this->clientHostAddressRestriction));
         foreach ($clientHostRestrictionAddresses as $clientHostAddressRestriction) {
-            if ($clientHostAddress == $clientHostAddressRestriction) {
-                return true;
+            if (filter_var($clientHostAddressRestriction, FILTER_VALIDATE_IP)) {
+                if ($clientHostAddress == $clientHostAddressRestriction) {
+                    return true;
+                }
+            } else {
+                $hostAccessRestrictions = gethostbynamel($clientHostAddressRestriction . '.');
+                foreach ($hostAccessRestrictions as $hostAccessRestriction) {
+                    if ($clientHostAddress == $hostAccessRestriction) {
+                        return true;
+                    }
+                }
             }
         }
         return false;

--- a/classes/class.tx_caretakerinstance_SecurityManager.php
+++ b/classes/class.tx_caretakerinstance_SecurityManager.php
@@ -272,10 +272,17 @@ class tx_caretakerinstance_SecurityManager implements tx_caretakerinstance_ISecu
      * @param string $clientHostAddress
      * @return bool
      */
-    private function isClientHostAddressValid($clientHostAddress) {
-        if(strlen($this->clientHostAddressRestriction) && $clientHostAddress != $this->clientHostAddressRestriction) {
-            return false;
+    private function isClientHostAddressValid($clientHostAddress)
+    {
+        if (!strlen($this->clientHostAddressRestriction)) {
+            return true;
         }
-        return true;
+        $clientHostRestrictionAddresses = array_map('trim', explode(',', $this->clientHostAddressRestriction));
+        foreach ($clientHostRestrictionAddresses as $clientHostAddressRestriction) {
+            if ($clientHostAddress == $clientHostAddressRestriction) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -7,5 +7,5 @@ crypto.instance.privateKey =
 # cat=basic/enable; type=string; label= Public key of the caretaker server : Required for Secure Communication with the caretaker Server. This key will encrypt the answers to the Caretaker server to ensure Privacy.
 crypto.client.publicKey =
 
-# cat=basic/enable; type=string; label= Optional - Caretaker Server Host host address : Restrict caretaker access to this IP address (should be the caretaker server address). You can add a single IP address or more as a comma separated list.
+# cat=basic/enable; type=string; label= Optional - Caretaker Server Host host address : Restrict caretaker access to this IP address or hostname (should be the caretaker server). You can add a single IP address / hostname or more as a comma separated list.
 security.clientHostAddressRestriction =

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -7,5 +7,5 @@ crypto.instance.privateKey =
 # cat=basic/enable; type=string; label= Public key of the caretaker server : Required for Secure Communication with the caretaker Server. This key will encrypt the answers to the Caretaker server to ensure Privacy.
 crypto.client.publicKey =
 
-# cat=basic/enable; type=string; label= Optional - Caretaker Server Host host address : Restrict caretaker access to this IP address (should be the caretaker server address)
+# cat=basic/enable; type=string; label= Optional - Caretaker Server Host host address : Restrict caretaker access to this IP address (should be the caretaker server address). You can add a single IP address or more as a comma separated list.
 security.clientHostAddressRestriction =


### PR DESCRIPTION
With this PR you can add multiple IPs and/or hostnames to `security.clientHostAddressRestriction` (comma separated)

Examples:

`security.clientHostAddressRestriction = 192.168.10.200`

`security.clientHostAddressRestriction = 192.168.10.200, 192.168.10.201`

`security.clientHostAddressRestriction = 192.168.10.200, microsoft.com`